### PR TITLE
fix: set syntax to jsx for javascriptreact and typescriptreact (#6)

### DIFF
--- a/lua/nvim-emmet/init.lua
+++ b/lua/nvim-emmet/init.lua
@@ -24,6 +24,10 @@ M.wrap_with_abbreviation = function()
 
         local opts = { text = utils.trim(to_replace) }
 
+        if vim.bo.filetype == "javascriptreact" or vim.bo.filetype == "typescriptreact" then
+            opts.syntax = "jsx"
+        end
+
         vim.lsp.buf_request(
             0,
             "emmet/expandAbbreviation",


### PR DESCRIPTION
This fixes #6, though I question whether the root of the issue may be with emmet_language_server itself?